### PR TITLE
Merge fix-from-string-instruction to master

### DIFF
--- a/src/propeller/problems/PSB2/camel_case.cljc
+++ b/src/propeller/problems/PSB2/camel_case.cljc
@@ -78,19 +78,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
                         (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/fizz_buzz.cljc
+++ b/src/propeller/problems/PSB2/fizz_buzz.cljc
@@ -46,19 +46,14 @@
                             (:step-limit argmap))
                           :string))
                       inputs)
-         parsed-outputs (map (fn [output]
-                               (try (read-string output)
-                                    #?(:clj (catch Exception e 1000.0)
-                                       :cljs (catch js/Error. e 1000.0))))
-                             outputs)
          errors (map (fn [correct-output output]
                        (if (= output :no-stack-item)
                          10000
-                         (metrics/levenshtein-distance (str correct-output) (str output))))
+                         (metrics/levenshtein-distance correct-output output)))
                      correct-outputs
-                     parsed-outputs)]
+                     outputs)]
      (assoc individual
-       :behaviors parsed-outputs
+       :behaviors outputs
        :errors errors
        :total-error #?(:clj  (apply +' errors)
                        :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/middle_character.cljc
+++ b/src/propeller/problems/PSB2/middle_character.cljc
@@ -47,19 +47,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (if (= output :no-stack-item)
-                                1000.0
-                                output))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
-                        (metrics/levenshtein-distance (str correct-output) (str output))))
+                        (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/middle_character.cljc
+++ b/src/propeller/problems/PSB2/middle_character.cljc
@@ -48,9 +48,9 @@
                          :string))
                      inputs)
         parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
+                              (if (= output :no-stack-item)
+                                1000.0
+                                output))
                             outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)

--- a/src/propeller/problems/PSB2/spin_words.cljc
+++ b/src/propeller/problems/PSB2/spin_words.cljc
@@ -74,19 +74,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
                         (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/square_digits.cljc
+++ b/src/propeller/problems/PSB2/square_digits.cljc
@@ -46,19 +46,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
-                        (metrics/levenshtein-distance (str correct-output) (str output))))
+                        (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/substitution_cipher.cljc
+++ b/src/propeller/problems/PSB2/substitution_cipher.cljc
@@ -59,19 +59,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
-                        (metrics/levenshtein-distance (str correct-output) (str output))))
+                        (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/twitter.cljc
+++ b/src/propeller/problems/PSB2/twitter.cljc
@@ -50,19 +50,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
-                        (metrics/levenshtein-distance (str correct-output) (str output))))
+                        (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/push/instructions/numeric.cljc
+++ b/src/propeller/push/instructions/numeric.cljc
@@ -121,9 +121,13 @@
     :name "_from_string"}
   (fn [stack state]
     (make-instruction state
-                      #(try ((if (= stack :integer) int float) (read-string %))
-                            #?(:clj (catch Exception e)
-                               :cljs (catch js/Error. e)))
+                      #(try (if (= stack :integer)
+                             #?(:clj (Integer/parseInt %)
+                                :cljs (js/parseInt %)) 
+                             #?(:clj (Float/parseFloat %) 
+                                :cljs (js/parseFloat %)))
+                            #?(:clj (catch Exception e :ignore-instruction)
+                               :cljs (catch js/Error e :ignore-instruction)))
                       [:string]
                       stack)))
 


### PR DESCRIPTION
This branch was created to fix the _from_string instruction because it never utilized :no-stack-item and sometimes put nil on the string stack.

Additionally, we modified Twitter and Middle-Character because they were unnecessarily using read-string on strings and then converting back to strings, which altered the output in some cases. After these changes were made, both test problems appear to be working a lot better.